### PR TITLE
Major Edits to hex-edit on MacOS:

### DIFF
--- a/hiro/cocoa/widget/hex-edit.hpp
+++ b/hiro/cocoa/widget/hex-edit.hpp
@@ -1,10 +1,13 @@
 #if defined(Hiro_HexEdit)
 
-@interface CocoaHexEdit : NSScrollView <NSTableViewDataSource>  {
+@interface CocoaHexEditTableView : NSTableView
+@end
+
+@interface CocoaHexEdit : NSScrollView <NSTableViewDataSource, NSTableViewDelegate> {
   // Not an NSTableViewDelegate because the table is cell-based, not view-based
 @public
   hiro::mHexEdit* hexEdit; // this will be the data source for tableView.
-  NSTableView* tableView;
+  CocoaHexEditTableView* tableView;
 }
 -(id) initWith:(hiro::mHexEdit&)hexEdit;
 -(NSTableView*) tableView; // helper function used in update()
@@ -17,7 +20,7 @@ struct pHexEdit : public pWidget {
   Declare(HexEdit, Widget);
 
   auto setAddress(u32 address) -> void;
-  auto setBase(u16 base) -> void;
+  auto setBase(u8 base) -> void;
   auto setBackgroundColor(Color color) -> void;
   auto setColumns(u32 columns) -> void;
   auto setForegroundColor(Color color) -> void;

--- a/hiro/core/widget/hex-edit.hpp
+++ b/hiro/core/widget/hex-edit.hpp
@@ -4,7 +4,7 @@ struct mHexEdit : mWidget {
 
   auto address() const -> u32;
   auto backgroundColor() const -> Color;
-  auto base() const -> u16;
+  auto base() const -> u8;
   auto columns() const -> u32;
   auto doRead(u32 offset) const -> u8;
   auto doWrite(u32 offset, u8 data) const -> void;
@@ -15,7 +15,7 @@ struct mHexEdit : mWidget {
   auto rows() const -> u32;
   auto setAddress(u32 address = 0) -> type&;
   auto setBackgroundColor(Color color = {}) -> type&;
-  auto setBase(u16 base) -> type&;
+  auto setBase(u8 base) -> type&;
   auto setColumns(u32 columns = 16) -> type&;
   auto setForegroundColor(Color color = {}) -> type&;
   auto setLength(u32 length) -> type&;
@@ -26,7 +26,7 @@ struct mHexEdit : mWidget {
   struct State {
     u32 address = 0;
     Color backgroundColor;
-    u16 base = 16;
+    u8 base = 16;
     u32 columns = 16;
     Color foregroundColor;
     u32 length = 0;

--- a/hiro/gtk/widget/hex-edit.cpp
+++ b/hiro/gtk/widget/hex-edit.cpp
@@ -94,7 +94,7 @@ auto pHexEdit::setAddress(u32 address) -> void {
   update();
 }
 
-auto pHexEdit::setBase(u16 base) -> void {
+auto pHexEdit::setBase(u8 base) -> void {
   setScroll();
   update();
 }

--- a/hiro/gtk/widget/hex-edit.hpp
+++ b/hiro/gtk/widget/hex-edit.hpp
@@ -7,7 +7,7 @@ struct pHexEdit : pWidget {
 
   auto focused() const -> bool override;
   auto setAddress(u32 address) -> void;
-  auto setBase(u16 base) -> void;
+  auto setBase(u8 base) -> void;
   auto setBackgroundColor(Color color) -> void;
   auto setColumns(u32 columns) -> void;
   auto setForegroundColor(Color color) -> void;

--- a/hiro/qt/widget/hex-edit.cpp
+++ b/hiro/qt/widget/hex-edit.cpp
@@ -40,7 +40,7 @@ auto pHexEdit::setAddress(u32 address) -> void {
   _setState();
 }
 
-auto pHexEdit::setBase(u32 base) -> void {
+auto pHexEdit::setBase(u8 base) -> void {
   _setState();
 }
 

--- a/hiro/qt/widget/hex-edit.hpp
+++ b/hiro/qt/widget/hex-edit.hpp
@@ -6,7 +6,7 @@ struct pHexEdit : pWidget {
   Declare(HexEdit, Widget)
 
   auto setAddress(u32 address) -> void;
-  auto setBase(u16 base) -> void;
+  auto setBase(u8 base) -> void;
   auto setBackgroundColor(Color color) -> void;
   auto setColumns(u32 columns) -> void;
   auto setForegroundColor(Color color) -> void;

--- a/hiro/windows/widget/hex-edit.cpp
+++ b/hiro/windows/widget/hex-edit.cpp
@@ -32,7 +32,7 @@ auto pHexEdit::setAddress(u32 address) -> void {
   update();
 }
 
-auto pHexEdit::setBase(u16 base) -> void {
+auto pHexEdit::setBase(u8 base) -> void {
   update();
 }
 

--- a/hiro/windows/widget/hex-edit.hpp
+++ b/hiro/windows/widget/hex-edit.hpp
@@ -6,7 +6,7 @@ struct pHexEdit : pWidget {
   Declare(HexEdit, Widget)
 
   auto setAddress(u32 address) -> void;
-  auto setBase(u16 base) -> void;
+  auto setBase(u8 base) -> void;
   auto setBackgroundColor(Color color) -> void;
   auto setColumns(u32 columns) -> void;
   auto setForegroundColor(Color color) -> void;


### PR DESCRIPTION
1. A single click and you can edit the contents of the cell/memory at an address
2. You can edit an address in either hexadecimal, binary, or octal depending on the Radio Button.
3. The base can be represented with u8 integer. So I changed that for every hex-edit no matter the platform.